### PR TITLE
Ignore CGAL build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1207,3 +1207,8 @@ gmon.*
 /Operations_on_polyhedra/examples/Operations_on_polyhedra/cgal_test_with_cmake
 /Operations_on_polyhedra/test/Operations_on_polyhedra/cgal_test_with_cmake
 lib/*
+*.dylib
+*.la
+*.lo.d
+*.lo
+.libs


### PR DESCRIPTION
All the stuff from our build shows up as "untracked content" in the contrib/cgal submodule, we can avoid this simply by ignoring those files.
